### PR TITLE
Updated basics to rep_on_read when reading raw MT

### DIFF
--- a/ukbb_qc/resources/basics.py
+++ b/ukbb_qc/resources/basics.py
@@ -45,8 +45,10 @@ def get_ukbb_data(
     :param bool split: Whether the dataset should be split (only applies to raw=False)
     :param bool ukbb_samples_only: Whether to return only UKBB samples (exclude control samples). Default is True.
     :param bool raw: Whether to return the raw data (not recommended: unsplit, and no special consideration on sex chromosomes)
-    :param bool repartition: Whether to repartition the MatrixTable. Required if raw is True. Default is False
-    :param int n_partitions: Number of desired partitions for MatrixTable. Required if raw is True. Default is 30000
+    :param bool repartition: Whether to repartition the MatrixTable. 
+        Required if raw is True for tranche 3/freeze 6. Default is False
+    :param int n_partitions: Number of desired partitions for MatrixTable. Applies only to raw MT.
+        Required if raw is True for tranche 3/freeze 6. Default is 30000
     :param str meta_root: Root annotation name for metadata (e.g., 'meta')
     :return: hardcalls dataset
     :rtype: MatrixTable


### PR DESCRIPTION
Necessary because raw MT was written with a small number of partitions and needs repartitioning