### PR TITLE
Added repartition to platform

### DIFF
--- a/ukbb_qc/sample_qc/platform_pca.py
+++ b/ukbb_qc/sample_qc/platform_pca.py
@@ -87,6 +87,7 @@ def main(args):
                 hdbscan_min_cluster_size=args.hdbscan_min_cluster_size,
                 hdbscan_min_samples=hdbscan_min_samples,
             )
+            platform_ht =  platform_ht.repartition(args.n_partitions)
             platform_ht = platform_ht.checkpoint(
                 platform_pca_assignments_ht_path(data_source, freeze),
                 overwrite=args.overwrite,


### PR DESCRIPTION
...because I saw this during the re-run:
```
2020-04-22 13:40:04 Hail: INFO: wrote table with 301842 rows in 1196 partitions to gs://broad-ukbb/broad.freeze_6/sample_qc/platform_pca/platform_pca_assignments.ht
```