### PR TITLE
VCF export fixes

### DIFF
--- a/ukbb_qc/release/prepare_vcf_data_release.py
+++ b/ukbb_qc/release/prepare_vcf_data_release.py
@@ -1032,6 +1032,7 @@ if __name__ == "__main__":
         "--n_shards",
         help="Desired number of shards for output VCF (if --parallelize is set). Will be used to repartition raw MT on read",
         type=int,
+        default=25000,
     )
     parser.add_argument(
         "--slack_channel", help="Slack channel to post results and notifications to."


### PR DESCRIPTION
- Added option to repartition VCF MT on read 
- Fixed calls to file that appends fields to VCF header
- Removed `description_text` parameter from calls to `make_info_dict` when populating gnomAD header descriptions. this is to prevent adding a duplicate "in gnomAD" string to the description