### PR TITLE
Fixed subpops check

### DIFF
--- a/ukbb_qc/assessment/sanity_checks.py
+++ b/ukbb_qc/assessment/sanity_checks.py
@@ -706,8 +706,8 @@ def sanity_check_release_mt(
     # The `histograms_sanity_check` code checks `_n_smaller` for all hists and
     # `_n_larger` for every hist except the DP hists
     # ^ we dropped all of these annotations in the 455k tranche
-    logger.info("HISTOGRAM CHECKS:")
-    histograms_sanity_check(ht, verbose=verbose)
+    # logger.info("HISTOGRAM CHECKS:")
+    # histograms_sanity_check(ht, verbose=verbose)
 
     logger.info("RAW AND ADJ CHECKS:")
     raw_and_adj_sanity_checks(ht, subsets, verbose)


### PR DESCRIPTION
I thought this was fixed previously, but the sanity checks code was still looking for subpops in the gnomAD genomes. This fixes that issue