### PR TITLE
Add build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,14 @@
+[metadata]
+name = ukbb_qc
+version = 0.0.1
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+    Topic :: Scientific/Engineering :: Bio-Informatics
+    Intended Audience :: Science/Research
+    Programming Language :: Python :: 3
+
+[options]
+packages = find:
+python_requires = >=3.6
+include_package_data = True


### PR DESCRIPTION
This adds build configuration that makes it possible to [pip install](https://pip.pypa.io/en/stable/cli/pip_install/) ukbb_qc. This does not include uploading ukbb_qc to PyPI, but allows pip installing from a local copy, a GitHub URL, etc.

More information about the configuration files added here:
* https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/
* https://setuptools.pypa.io/en/latest/userguide/declarative_config.html

The motivation for this was broadinstitute/gnomad_qc#218, which adds some imports from ukbb_qc. This will make it easier to install ukbb_qc in gnomad_qc's PR check workflows, which will let us check gnomad_qc's usage of it using Pylint. This will also let us install ukbb_qc on Dataproc clusters using `hailctl dataproc`'s `--packages` argument.

A few limitations... this does not list dependencies, so they will not be automatically installed. Similar to gnomad_methods, we don't want to automatically install Hail because it causes issues when installing on a cluster using `hailctl dataproc`.

This also adds a .gitignore file, copied from [GitHub's Python example](https://github.com/github/gitignore/blob/cdd9e946da421758c6f42c427c7bc65c8326155d/Python.gitignore). This is included here to ignore build outputs (`build`, `ukbb_qc.egg-info`).